### PR TITLE
Ingmar Verheij patch 1

### DIFF
--- a/src/beacon-manager.coffee
+++ b/src/beacon-manager.coffee
@@ -19,10 +19,7 @@ class BeaconManager extends EventEmitter
     @_intervalCleanup = setInterval @cleanupArray, 10 * 1000  # Check every 10 sec if we need to cleanup the array 
 
   cleanupArray: =>
-    @beacons_alive = []
-    for beacon in @beacons
-       @beacons_alive.push beacon if beacon.isAlive()
-    @beacons = @beacons_alive
+    @beacons = _.reject @beacons, { major: -1 }
 
   clearBeacons: (callback) =>
     async.each @beacons, (beacon, done) =>
@@ -70,7 +67,7 @@ class BeaconManager extends EventEmitter
 
     beacon = new Beacon {beacon: data, @broadcastProximityChange, @broadcastRssiChange, @rssiDelta, @timeout}
     beacon.on 'data', @_onData
-    beacon.initialize 
+    beacon.initialize() 
     @beacons.push beacon
 
 module.exports = BeaconManager

--- a/src/beacon-manager.coffee
+++ b/src/beacon-manager.coffee
@@ -16,6 +16,13 @@ class BeaconManager extends EventEmitter
     @Bleacon = Bleacon
     @beacons = []
     @Bleacon.on 'discover', @_onDiscover
+    @_intervalCleanup = setInterval @cleanupArray, 10 * 1000  # Check every 10 sec if we need to cleanup the array 
+
+  cleanupArray: =>
+    @beacons_alive = []
+    for beacon in @beacons
+       @beacons_alive.push beacon if beacon.isAlive()
+    @beacons = @beacons_alive
 
   clearBeacons: (callback) =>
     async.each @beacons, (beacon, done) =>
@@ -63,6 +70,7 @@ class BeaconManager extends EventEmitter
 
     beacon = new Beacon {beacon: data, @broadcastProximityChange, @broadcastRssiChange, @rssiDelta, @timeout}
     beacon.on 'data', @_onData
+    beacon.initialize 
     @beacons.push beacon
 
 module.exports = BeaconManager

--- a/src/beacon.coffee
+++ b/src/beacon.coffee
@@ -5,12 +5,19 @@ moment         = require 'moment'
 class Beacon extends EventEmitter
   constructor: ({ @beacon, @broadcastProximityChange, @broadcastRssiChange, @rssiDelta, @timeout }={}) ->
     @_emit = _.throttle @emit, 500, {leading: true, trailing: false}
-    @update @beacon
     @_initializeGoneInterval()
 
+  initialize:  => 
+    @_emitData @beacon, _.noop, true
+    
   close: (callback=_.noop) =>
     clearInterval @_intervalGone
+    @beacon.major = -1 # Mark this class for destruction
     callback()
+
+  isAlive: () =>
+    return true unless @beacon.major == -1
+    return false
 
   is: (matchBeacon) =>
     { uuid, major, minor } = @beacon
@@ -33,7 +40,7 @@ class Beacon extends EventEmitter
 
   _initializeGoneInterval: =>
     return unless @timeout > 0
-    @_intervalGone = setInterval @_checkIfGone, @timeout * 1000
+    @_intervalGone = setInterval @_checkIfGone, 500
 
   _checkIfGone: =>
     since = moment().subtract @timeout, 'seconds'
@@ -43,8 +50,8 @@ class Beacon extends EventEmitter
       measuredPower: 0
       rssi: 0
       accuracy: 0
-    @_emitData _.defaults defaults, @beacon, =>
-      @close()
+    @_emitData _.defaults defaults, @beacon
+    @close()
 
   update: (@beacon, callback=_.noop) =>
     return unless @beacon?

--- a/src/beacon.coffee
+++ b/src/beacon.coffee
@@ -8,12 +8,11 @@ class Beacon extends EventEmitter
     @_initializeGoneInterval()
 
   initialize:  => 
-    @_emitData @beacon, _.noop, true
+    @_emitData @beacon, true
     
-  close: (callback=_.noop) =>
+  close: () =>
     clearInterval @_intervalGone
     @beacon.major = -1 # Mark this class for destruction
-    callback()
 
   isAlive: () =>
     return true unless @beacon.major == -1
@@ -58,9 +57,9 @@ class Beacon extends EventEmitter
     @updatedAt = moment()
     return callback() unless @_hasRssiChanged() || @_hasProximityChanged()
     {@rssi, @proximity} = @beacon
-    @_emitData @beacon, callback
+    @_emitData @beacon
 
-  _emitData: (data, callback=_.noop) =>
+  _emitData: (data) =>
     fields = [
       'uuid'
       'major'
@@ -71,6 +70,5 @@ class Beacon extends EventEmitter
       'proximity'
     ]
     @_emit 'data', _.pick data, fields
-    callback()
 
 module.exports = Beacon


### PR DESCRIPTION
A few bug fixes:
* On first discovery no event was triggered (because @_onData was initialised after the event)
* The ‘gone’ event was triggered indefinitely
* When a beacon was ‘gone’ the timer was cleared. When the same beacon came back the timer was never started.
* For every beacon that came in range an instance of beacon.coffee was created and never cleaned up, which could lead to scalability issues


PS: Please double-check the @cleanupArray function in beacon-manager